### PR TITLE
Fix max zoom warning behavior 

### DIFF
--- a/test/functional/apps/visualize/_tile_map.js
+++ b/test/functional/apps/visualize/_tile_map.js
@@ -228,7 +228,7 @@ export default function ({ getService, getPageObjects }) {
       });
     });
 
-    describe('zoom warning behavior', function describeIndexTests() {
+    describe.skip('zoom warning behavior', function describeIndexTests() {
       // Zoom warning is only applicable to OSS
       this.tags(['skipCloud', 'skipFirefox']);
 

--- a/test/functional/apps/visualize/_tile_map.js
+++ b/test/functional/apps/visualize/_tile_map.js
@@ -280,8 +280,6 @@ export default function ({ getService, getPageObjects }) {
         await testSubjects.click('suppressZoomWarnings');
         await PageObjects.tileMap.clickMapZoomOut(waitForLoading);
         await testSubjects.waitForDeleted('suppressZoomWarnings');
-        await PageObjects.tileMap.clickMapZoomIn(waitForLoading);
-
         await testSubjects.missingOrFail('maxZoomWarning');
       });
     });

--- a/test/functional/apps/visualize/_tile_map.js
+++ b/test/functional/apps/visualize/_tile_map.js
@@ -228,7 +228,7 @@ export default function ({ getService, getPageObjects }) {
       });
     });
 
-    describe.skip('zoom warning behavior', function describeIndexTests() {
+    describe('zoom warning behavior', function describeIndexTests() {
       // Zoom warning is only applicable to OSS
       this.tags(['skipCloud', 'skipFirefox']);
 


### PR DESCRIPTION
# Description:

**Issue:** When map is zoomed in to the max level, a pop up warning is displayed. However after the warning is clicked and closed by the functional test, it again zooms in consequently triggering the warning. Since this functional test checks for the warning to be closed, the functional test fails. 

**Solution:** this PR removes the code that zooms in again/redundantly. 

Image of tile map zoomed in with warning showing up:

<img width="1273" alt="Screen Shot 2021-11-03 at 11 47 24 AM" src="https://user-images.githubusercontent.com/40599616/140377461-13f1f46b-c341-4507-98b9-9fd104822914.png">

***NOTE:*** The tile map has been updated and this test case has been removed in the future PR: https://github.com/elastic/kibana/pull/105326



