### PR TITLE
Skipped flaky test

### DIFF
--- a/src/dev/build/lib/scan_copy.test.ts
+++ b/src/dev/build/lib/scan_copy.test.ts
@@ -76,7 +76,7 @@ it('rejects if neither path is absolute', async () => {
   );
 });
 
-it('copies files and directories from source to dest, including dot files, creating dest if necessary, respecting mode', async () => {
+it.skip('copies files and directories from source to dest, including dot files, creating dest if necessary, respecting mode', async () => {
   const destination = resolve(TMP, 'a/b/c');
   await scanCopy({
     source: FIXTURES,


### PR DESCRIPTION
## Summary

This test expects windows platform to output code 644. This passes when testing on local machine, however, gives a flaky result on jenkins. The proposal is to skip this test. 

