### PR TITLE
Fix for functional test jUnit path

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,7 +82,7 @@ node {
         stage('Functional Test') {
             echo "Starting functional test..."
             functionalDynamicParallelSteps(testImage);
-            junit 'target/junit/ci* *.xml'
+            junit 'target/junit/ci*/**.xml'
         }
     } catch (e) {
             echo 'This will run only if failed'


### PR DESCRIPTION
# Description:

Even though all tests pass, Jenkins test job fails due to invalid jUnit path. This PR fixes the error. A jenkins job was run to verify it successfully resolves issue.

Closes issue #33 

Jenkins job: https://jenkins.bfs.sichend.people.aws.dev/job/Kibana/job/bfs7.7.1/165/