### PR TITLE
Unit Tests Skipped

### DIFF
--- a/src/cli_plugin/lib/error_if_x_pack.test.js
+++ b/src/cli_plugin/lib/error_if_x_pack.test.js
@@ -20,7 +20,7 @@
 
 import { errorIfXPackInstall, errorIfXPackRemove } from './error_if_x_pack';
 
-describe('error_if_xpack', () => {
+describe.skip('error_if_xpack', () => {
   it('should error on install if x-pack by name', () => {
     expect(() => errorIfXPackInstall({ plugin: 'x-pack' })).toThrow();
   });

--- a/src/cli_plugin/lib/is_oss.test.js
+++ b/src/cli_plugin/lib/is_oss.test.js
@@ -19,7 +19,7 @@
 
 import { isOSS } from './is_oss';
 
-describe('is_oss', () => {
+describe.skip('is_oss', () => {
   describe('x-pack installed', () => {
     it('should return false', () => {
       expect(isOSS()).toEqual(false);

--- a/src/cli_plugin/remove/remove.test.js
+++ b/src/cli_plugin/remove/remove.test.js
@@ -78,7 +78,7 @@ describe('kibana cli', function () {
       expect(existsSync(settings.pluginPath)).toEqual(false);
     });
 
-    it('distribution error if x-pack does not exist', () => {
+    it.skip('distribution error if x-pack does not exist', () => {
       settings.pluginPath = join(pluginDir, 'x-pack');
       settings.plugin = 'x-pack';
       expect(existsSync(settings.pluginPath)).toEqual(false);

--- a/src/dev/build/lib/scan_copy.test.ts
+++ b/src/dev/build/lib/scan_copy.test.ts
@@ -79,7 +79,7 @@ it('rejects if neither path is absolute', async () => {
   );
 });
 
-it('copies files and directories from source to dest, including dot files, creating dest if necessary, respecting mode', async () => {
+it.skip('copies files and directories from source to dest, including dot files, creating dest if necessary, respecting mode', async () => {
   const destination = resolve(TMP, 'a/b/c');
   await scanCopy({
     source: FIXTURES,


### PR DESCRIPTION
# Description :
> est Tests.src/dev/build/lib.copies files and directories from source to dest, including dot files, creating dest if necessary, respecting mode (from src_dev_build_lib_scan_copy.test.ts) 

This flaky test was identified in PR: #28. It expects "Is_windows" to be either 644 or 666. This works on local machine and outputs 644. However, the output is flaky on Jenkins and results in "664". This test file has also been removed in branch 7.10

x-pack files/directories removed therefore the other failed tests need to be skipped.

### Closes Issue #35 