### PR TITLE
downgrade jest-junit to 10.0.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ node {
             sh 'mkdir junit-test'
 
             stage('Bootstrap') {
-                sh 'yarn add --dev jest-junit'
+                sh 'yarn add --dev jest-junit@10.0.0'
                 sh 'google-chrome --version'
                 sh 'yarn kbn bootstrap'
             }


### PR DESCRIPTION
# Description:

Jest-junit requires node >= 10, while bfs 6.5.4 uses node v8.19.0. This PR downgrades jest-junit to v10.0.0 to be complacent to node v8.

jest-junit v10.0.0 node compatibility: https://github.com/jest-community/jest-junit/blob/87e3413fce60dfd420f78aa0b6a47cf98600134a/package.json#L10

Closes issue #49 