### PR TITLE
Fix x-pack related test failures

### DIFF
--- a/src/cli_plugin/lib/error_if_x_pack.test.js
+++ b/src/cli_plugin/lib/error_if_x_pack.test.js
@@ -40,7 +40,7 @@ describe('error_if_xpack', () => {
       }))
     ).not.toThrow();
   });
-
+  // This test has been skipped due to its redundancy. It fails if x-pack is removed. Note: The whole x-pack directory has been removed!
   it.skip('should error on remove if x-pack', () => {
     expect(() => errorIfXPackRemove({ plugin: 'x-pack' })).toThrow();
   });

--- a/src/cli_plugin/lib/error_if_x_pack.test.js
+++ b/src/cli_plugin/lib/error_if_x_pack.test.js
@@ -41,7 +41,7 @@ describe('error_if_xpack', () => {
     ).not.toThrow();
   });
 
-  it('should error on remove if x-pack', () => {
+  it.skip('should error on remove if x-pack', () => {
     expect(() => errorIfXPackRemove({ plugin: 'x-pack' })).toThrow();
   });
 

--- a/src/cli_plugin/lib/is_oss.test.js
+++ b/src/cli_plugin/lib/is_oss.test.js
@@ -19,7 +19,7 @@
 
 import { isOSS } from './is_oss';
 
-describe('is_oss', () => {
+describe.skip('is_oss', () => {
   describe('x-pack installed', () => {
     it('should return false', () => {
       expect(isOSS()).toEqual(false);

--- a/src/cli_plugin/lib/is_oss.test.js
+++ b/src/cli_plugin/lib/is_oss.test.js
@@ -18,7 +18,7 @@
  */
 
 import { isOSS } from './is_oss';
-
+// this test is skipped because it fails if x-pack isn't installed. Note: The whole x-pack directory has been removed!
 describe.skip('is_oss', () => {
   describe('x-pack installed', () => {
     it('should return false', () => {

--- a/src/cli_plugin/remove/remove.test.js
+++ b/src/cli_plugin/remove/remove.test.js
@@ -78,7 +78,7 @@ describe('kibana cli', function () {
       expect(existsSync(settings.pluginPath)).toEqual(false);
     });
 
-    it('distribution error if x-pack does not exist', () => {
+    it.skip('distribution error if x-pack does not exist', () => {
       settings.pluginPath = join(pluginDir, 'x-pack');
       settings.plugin = 'x-pack';
       expect(existsSync(settings.pluginPath)).toEqual(false);

--- a/src/cli_plugin/remove/remove.test.js
+++ b/src/cli_plugin/remove/remove.test.js
@@ -77,7 +77,7 @@ describe('kibana cli', function () {
       remove(settings, logger);
       expect(existsSync(settings.pluginPath)).toEqual(false);
     });
-
+    // this test is skipped because it uses x-pack in test case. Note: The whole x-pack directory has been removed!
     it.skip('distribution error if x-pack does not exist', () => {
       settings.pluginPath = join(pluginDir, 'x-pack');
       settings.plugin = 'x-pack';

--- a/src/dev/typescript/projects.ts
+++ b/src/dev/typescript/projects.ts
@@ -25,8 +25,6 @@ import { Project } from './project';
 
 export const PROJECTS = [
   new Project(resolve(REPO_ROOT, 'tsconfig.json')),
-  new Project(resolve(REPO_ROOT, 'x-pack/tsconfig.json')),
-  new Project(resolve(REPO_ROOT, 'x-pack/test/tsconfig.json'), 'x-pack/test'),
 
   // NOTE: using glob.sync rather than glob-all or globby
   // because it takes less than 10 ms, while the other modules


### PR DESCRIPTION
# Description:

This PR fixes the following x-pack related test failures:

1. Removes `x-pack/tsconfig.json` and `x-pack/test/(*|**)` from root directory. This was causing jenkins unit failure by adding x-pack tsconfig.json file to test files. 

- **Jenkins Unit Test Failure Report:** https://jenkins.bfs.sichend.people.aws.dev/job/Kibana/job/bfs6.5.4/7/console

2. Skips x-pack related tests

Closes issue #51 