### PR TITLE
downgrade chrome v94 --> v89

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,7 @@ node {
             stage('Bootstrap') {
                 sh 'yarn add --dev jest-junit'
                 sh 'google-chrome --version'
+                sh 'yarn add chromedriver --detect_chromedriver_version'
                 sh 'yarn kbn bootstrap'
             }
 

--- a/dockerfile
+++ b/dockerfile
@@ -11,7 +11,7 @@ libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 lib
 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget openjdk-8-jre && \
 rm -rf /var/lib/apt/lists/*
 
-RUN curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add - && apt-get update && apt-get install -y rsync jq bsdtar --no-install-recommends && wget https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_94.0.4606.81-1_amd64.deb -O /tmp/google-chrome.deb && apt install -y /tmp/google-chrome.deb && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add - && apt-get update && apt-get install -y rsync jq bsdtar --no-install-recommends && wget https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_89.0.4389.90-1_amd64.deb -O /tmp/google-chrome.deb && apt install -y /tmp/google-chrome.deb && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN apt-get update && apt-get install -y python-pip
 


### PR DESCRIPTION
# Description:

Chrome v94 requires node >= 10.17.0, however, current node version is 10.15.2. This PR downgrades chrome to v89, which supports node 10.15.2. 

Closes #53 