### PR TITLE
Change docker image naming convention for BFS7.4.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ node {
     def kibanaVersion = '7.4.2'
     def scmVars = checkout scm
     sh "env"
-    def imageName = "${env.JOB_BASE_NAME}-test-image:${env.BUILD_ID}"
+    def imageName = "${env.BRANCH_NAME}-test-image:${env.BUILD_ID}"
     def testImage
 
     stage('Build container image') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ node {
     def kibanaVersion = '7.4.2'
     def scmVars = checkout scm
     sh "env"
-    def imageName = "test-image:${env.BUILD_ID}"
+    def imageName = "${env.JOB_BASE_NAME}-test-image:${env.BUILD_ID}"
     def testImage
 
     stage('Build container image') {


### PR DESCRIPTION
# Description:

This PR fixes the naming convention of the docker image. In jenkins job number 17 for bfs7.7.1 and bfs 6.5.4, two separate jobs but with the same name "test-image:17" were concurrently ran. This caused failure in the node environment because the jenkins job for bfs7.7.1 and bfs6.5.4 was pointing to the same docker container "test-image:17"

bfs7.7.1 job 17: https://jenkins.bfs.sichend.people.aws.dev/job/Kibana/job/bfs7.7.1/17/
bfs6.5.4 job 17: https://jenkins.bfs.sichend.people.aws.dev/job/Kibana/job/bfs6.5.4/17/