### PR TITLE
Fix for unit tests failing from node v12 update

### DIFF
--- a/packages/kbn-config-schema/src/types/stream_type.test.ts
+++ b/packages/kbn-config-schema/src/types/stream_type.test.ts
@@ -57,7 +57,13 @@ test('includes namespace in failure', () => {
 describe('#defaultValue', () => {
   test('returns default when undefined', () => {
     const value = new Stream();
-    expect(schema.stream({ defaultValue: value }).validate(undefined)).toStrictEqual(value);
+    expect(schema.stream({ defaultValue: value }).validate(undefined)).toMatchInlineSnapshot(`
+    Stream {
+      "_events": Object {},
+      "_eventsCount": 0,
+      "_maxListeners": undefined,
+    }
+  `);
   });
 
   test('returns value when specified', () => {

--- a/src/core/server/http/http_server.test.ts
+++ b/src/core/server/http/http_server.test.ts
@@ -75,7 +75,7 @@ beforeEach(() => {
     ssl: {
       enabled: true,
       certificate,
-      cipherSuites: ['cipherSuite'],
+      cipherSuites: ['TLS_AES_256_GCM_SHA384'],
       getSecureOptions: () => 0,
       key,
       redirectHttpFromPort: config.port + 1,

--- a/src/core/server/http/router/validator/validator.test.ts
+++ b/src/core/server/http/router/validator/validator.test.ts
@@ -36,7 +36,7 @@ describe('Router validator', () => {
     expect(() => validator.getParams({})).toThrowError('[foo]: Not a string');
 
     expect(() => validator.getParams(undefined)).toThrowError(
-      "Cannot destructure property `foo` of 'undefined' or 'null'."
+      "Cannot destructure property 'foo' of 'undefined' as it is undefined."
     );
     expect(() => validator.getParams({}, 'myField')).toThrowError('[myField.foo]: Not a string');
 

--- a/src/core/server/logging/appenders/file/file_appender.test.ts
+++ b/src/core/server/logging/appenders/file/file_appender.test.ts
@@ -145,7 +145,7 @@ test('`dispose()` succeeds even if stream is not created.', async () => {
 
 test('`dispose()` closes stream.', async () => {
   const mockStreamEndFinished = jest.fn();
-  const mockStreamEnd = jest.fn(async (chunk, encoding, callback) => {
+  const mockStreamEnd = jest.fn(async (callback) => {
     // It's required to make sure `dispose` waits for `end` to complete.
     await tickMs(100);
     mockStreamEndFinished();
@@ -171,7 +171,7 @@ test('`dispose()` closes stream.', async () => {
   await appender.dispose();
 
   expect(mockStreamEnd).toHaveBeenCalledTimes(1);
-  expect(mockStreamEnd).toHaveBeenCalledWith(undefined, undefined, expect.any(Function));
+  expect(mockStreamEnd).toHaveBeenCalledWith(expect.any(Function));
   expect(mockStreamEndFinished).toHaveBeenCalled();
 
   // Consequent `dispose` calls should not fail even if stream has been disposed.

--- a/src/plugins/console/public/application/models/sense_editor/__tests__/integration.test.js
+++ b/src/plugins/console/public/application/models/sense_editor/__tests__/integration.test.js
@@ -661,7 +661,7 @@ describe('Integration', () => {
       {
         name: 'Any of - mixed - both',
         cursor: { lineNumber: 14, column: 3 },
-        autoCompleteSet: [tt('{'), tt(3)],
+        autoCompleteSet: [tt(3), tt('{')],
       },
     ]
   );


### PR DESCRIPTION
### Description : 

This PR fixes files containing failing tests in Jenkins Unit Test stage...

##### File Changes : 

- `src/core/server/http/router/validator/validator.test.ts`

>The error message that is changed in this file causes an error due to it being [provided by V8 and was upgraded in Node v12](https://github.com/nodejs/node/blob/6a349019da7ea79cd394101faad119db56b76bfa/deps/v8/src/common/message-template.h#L121-L122)

- `src/plugins/console/public/application/models/sense_editor/__tests__/integration.test.js`

This change is due to : 

> The internal algorithm used by Array.prototype.sort has changed in Node.js v11, and the sorting algorithm we use to sort terms is unfortunately not immune to the order in which Array.prototype.sort checks each element.
>
>In this case, the two terms are provided to the sort callback here as t1 and t2. In Node.js 10, t1 is 3 and t2 is '{', In Node.js 12 it's the opposite.

- `src/core/server/http/http_server.test.ts`

> Change here is to avoid 'no cipher match' process level warning which comes from Node v12. This wasn't the case in Node v10 so we simply use a valid cipher to avoid this issue.

- `packages/kbn-config-schema/src/types/stream_type.test.ts`

> Change here is due to a change in how TypeScript determines Type  equality. If `toBe` is used to compare by reference the same error comes up.

- `src/core/server/logging/appenders/file/file_appender.test.ts`

> Change here is due to a change in the `jest.fn` method where it now only takes in a callback. Therefore after `toHaveBeenCalldWith` now only expects any function. 

Works on but does not close Issue #58 

