### PR TITLE
Remove @hapi/shot dependency as it is not needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -291,7 +291,6 @@
     "@elastic/eslint-plugin-eui": "0.0.2",
     "@elastic/github-checks-reporter": "0.0.20b3",
     "@elastic/makelogs": "^5.0.0",
-    "@hapi/shot": "^5.0.5",
     "@kbn/dev-utils": "1.0.0",
     "@kbn/es": "1.0.0",
     "@kbn/eslint-import-resolver-kibana": "2.0.0",


### PR DESCRIPTION
### Description : 
- Removes `@hapi/shot` dependency as it is already a dependency of the installed module `@hapi/hapi` and is therefore not needed.

Refer to Issue #64