### PR TITLE
Removed x-pack dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -259,7 +259,6 @@
     "webpack-merge": "4.1.4",
     "whatwg-fetch": "^3.0.0",
     "wreck": "^14.0.2",
-    "x-pack": "6.7.2",
     "yauzl": "2.7.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description : 
- Dependency caused bootstrap to fail while resolving packages and removing it clears this error and allows bootstrap to complete successfully. 

