### PR TITLE
Add run es & run kbn stages to 6.7.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,6 +29,20 @@ node('test') {
                 sh 'yarn kbn bootstrap'
             }
 
+            stage('Run ES'){
+                withCredentials([[
+                    $class: 'AmazonWebServicesCredentialsBinding',
+                    credentialsId: 'bfs-jenkins',
+                    accessKeyVariable: 'AWS_ACCESS_KEY_ID',
+                    secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'
+                ]]) {
+                    sh 'aws s3 cp s3://kibana.bfs.vendor/aes/elasticsearch/elasticsearch-oss-6.7.2.tar.gz ./'
+                    echo 'Start Elasticsearch'
+                    sh 'tar -xf elasticsearch-oss-6.7.2.tar.gz'
+                    sh './elasticsearch-6.7.2/bin/elasticsearch &'
+                } 
+            }
+
             stage('Unit Test') {
                 echo "Starting unit test..."
                 def utResult = sh returnStatus: true, script: 'CI=1 GCS_UPLOAD_PREFIX=fake yarn test:jest -u --ci'


### PR DESCRIPTION
### Description : 
- Adds `Run ES` & `Run Kibana` stages to jenkinsfile
- These versions are not supported to must be installed via s3 bucket
#### Test : [6.7.2_test Jenkins job #27](https://jenkins.bfs.sichend.people.aws.dev/blue/organizations/jenkins/Kibana/detail/bfs6.7.2_test/27/pipeline)

##### Resolves : Issue #99