### PR TITLE
Downgrade chrome

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,32 +25,32 @@ node("test") {
 
             stage('Bootstrap') {
                 sh 'yarn add --dev jest-junit@7'
+                sh 'yarn add --dev chromedriver@79'
                 sh 'which google-chrome'
-                sh 'which chromedriver'
                 sh 'yarn kbn bootstrap'
             }
 
-            // stage('Unit Test') {
-            //     echo "Starting Unit Test..."
-            //     def utResult = sh returnStatus: true, script: 'CI=1 GCS_UPLOAD_PREFIX=fake node scripts/jest -u --ci'
+            stage('Unit Test') {
+                echo "Starting Unit Test..."
+                def utResult = sh returnStatus: true, script: 'CI=1 GCS_UPLOAD_PREFIX=fake node scripts/jest -u --ci'
 
-            //     if (utResult != 0) {
-            //         currentBuild.result = 'FAILURE'
-            //     }
+                if (utResult != 0) {
+                    currentBuild.result = 'FAILURE'
+                }
                 
-            //     junit 'target/junit/TEST-Jest Tests*.xml'
-            // }
+                junit 'target/junit/TEST-Jest Tests*.xml'
+            }
 
-            // stage('Integration Test') {
-            //     echo "Start Integration Tests"
-            //     def itResult = sh returnStatus: true, script: 'CI=1 GCS_UPLOAD_PREFIX=fake node scripts/jest_integration -u --ci'
+            stage('Integration Test') {
+                echo "Start Integration Tests"
+                def itResult = sh returnStatus: true, script: 'CI=1 GCS_UPLOAD_PREFIX=fake node scripts/jest_integration -u --ci'
 
-            //     if (itResult != 0) {
-            //         currentBuild.result = 'FAILURE'
-            //     }
+                if (itResult != 0) {
+                    currentBuild.result = 'FAILURE'
+                }
 
-            //     junit 'target/junit/TEST-Jest Integration Tests*.xml'
-            // }
+                junit 'target/junit/TEST-Jest Integration Tests*.xml'
+            }
             
             stage('Run Elastic Search'){
                 withCredentials([[

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ node("test") {
 
             stage('Bootstrap') {
                 sh 'yarn add --dev jest-junit@7'
-                sh 'yarn add --dev chromedriver@79'
+                sh 'yarn add --dev chromedriver@79.0.3'
                 sh 'which google-chrome'
                 sh 'yarn kbn bootstrap'
             }

--- a/dockerfile
+++ b/dockerfile
@@ -7,15 +7,15 @@ ENV HOME '.'
 RUN apt-get update && apt-get -y install xvfb gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 \
 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 \
 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
-unzip libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 \
+awscli libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 \
 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget openjdk-8-jre && \
 rm -rf /var/lib/apt/lists/*
 
 RUN curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add - && apt-get update \
-&& apt-get install -y rsync jq bsdtar --no-install-recommends && wget -O /tmp/chrome-linux.zip "https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Linux_x64%2F706915%2Fchrome-linux.zip?generation=1571324979333057&alt=media" \
-&& unzip /tmp/chrome-linux.zip -d /tmp/ && cp /tmp/chrome-linux/chrome /usr/bin/google-chrome \
-&& wget -O /tmp/Linux_x64_698801_chromedriver_linux64.zip "https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Linux_x64%2F698801%2Fchromedriver_linux64.zip?generation=1569200203315649&alt=media" \
-&& unzip /tmp/Linux_x64_698801_chromedriver_linux64.zip -d /tmp/ && cp /tmp/chromedriver_linux64/chromedriver /usr/bin/chromedriver && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+&& apt-get install -y rsync jq bsdtar --no-install-recommends
+
+RUN aws s3 cp s3://kibana.bfs.vendor/aes/chrome/google-chrome-stable_79.0.3945.117-1_amd64.deb /tmp/google-chrome.deb \
+&& apt install -y /tmp/google-chrome.deb && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN apt-get update && apt-get install -y python-pip
 


### PR DESCRIPTION
# Description:

Latest chrome versions do not support node v8, which bfs6.5.4 is using. Chrome version v79 and lower support node v8. This PR downgrades chrome to v79. 

Closes #94 