### PR TITLE
Add Integration Test stage to Jenkinsfile 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,6 +59,17 @@ node('test') {
                 junit 'target/junit/TEST-Jest Tests*.xml'
             }
 
+            stage('Integration Test') {
+                echo "Start Integration Tests"
+                def itResult = sh returnStatus: true, script: 'CI=1 GCS_UPLOAD_PREFIX=fake node scripts/jest_integration -u --ci'
+
+                if (itResult != 0) {
+                    currentBuild.result = 'FAILURE'
+                }
+
+                junit 'target/junit/TEST-Jest Integration Tests*.xml'
+            }
+
         }     
     } catch (e) {
         echo 'This will run only if failed'


### PR DESCRIPTION
### Description : 
- Adds `Integration Test` stage to Jenkinsfile 
#### Test : Jenkins Job [#38](https://jenkins.bfs.sichend.people.aws.dev/blue/organizations/jenkins/Kibana/detail/bfs6.7.2_test/38/pipeline)
#### Note : 
- This runs with 2 reported failed tests in `src/cli/serve/integration_tests/reload_logging_config.test.js` resulting in an unstable build which will be fixed in the next PR

##### Closes Issue #105 