### PR TITLE
Fix for failing unit test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,27 +30,27 @@ node("test") {
                 sh 'yarn kbn bootstrap'
             }
 
-            // stage('Unit Test') {
-            //     echo "Starting Unit Test..."
-            //     def utResult = sh returnStatus: true, script: 'CI=1 GCS_UPLOAD_PREFIX=fake node scripts/jest -u --ci'
+            stage('Unit Test') {
+                echo "Starting Unit Test..."
+                def utResult = sh returnStatus: true, script: 'CI=1 GCS_UPLOAD_PREFIX=fake node scripts/jest -u --ci'
 
-            //     if (utResult != 0) {
-            //         currentBuild.result = 'FAILURE'
-            //     }
+                if (utResult != 0) {
+                    currentBuild.result = 'FAILURE'
+                }
                 
-            //     junit 'target/junit/TEST-Jest Tests*.xml'
-            // }
+                junit 'target/junit/TEST-Jest Tests*.xml'
+            }
 
-            // stage('Integration Test') {
-            //     echo "Start Integration Tests"
-            //     def itResult = sh returnStatus: true, script: 'CI=1 GCS_UPLOAD_PREFIX=fake node scripts/jest_integration -u --ci'
+            stage('Integration Test') {
+                echo "Start Integration Tests"
+                def itResult = sh returnStatus: true, script: 'CI=1 GCS_UPLOAD_PREFIX=fake node scripts/jest_integration -u --ci'
 
-            //     if (itResult != 0) {
-            //         currentBuild.result = 'FAILURE'
-            //     }
+                if (itResult != 0) {
+                    currentBuild.result = 'FAILURE'
+                }
 
-            //     junit 'target/junit/TEST-Jest Integration Tests*.xml'
-            // }
+                junit 'target/junit/TEST-Jest Integration Tests*.xml'
+            }
             
             stage('Run Elastic Search'){
                 withCredentials([[

--- a/src/server/saved_objects/serialization/index.ts
+++ b/src/server/saved_objects/serialization/index.ts
@@ -22,7 +22,7 @@
  * the raw document format as stored in ElasticSearch.
  */
 
-import uuid from 'uuid';
+import { v1 as uuidv1 } from 'uuid';
 import { SavedObjectsSchema } from '../schema';
 
 /**
@@ -145,7 +145,7 @@ export class SavedObjectsSerializer {
   public generateRawId(namespace: string | undefined, type: string, id?: string) {
     const namespacePrefix =
       namespace && !this.schema.isNamespaceAgnostic(type) ? `${namespace}:` : '';
-    return `${namespacePrefix}${type}:${id || uuid.v1()}`;
+    return `${namespacePrefix}${type}:${id || uuidv1()}`;
   }
 
   private trimIdPrefix(namespace: string | undefined, type: string, id: string) {


### PR DESCRIPTION
# Description:

Currently, 20 unit tests fail. These failures are related to the following:
1. API call fails when invoking uuid.v1(). Error log: (https://jenkins.bfs.sichend.people.aws.dev/job/Kibana/job/bfs6.5.4_test/69/#showFailuresLink):
```
TypeError: Cannot read property 'v1' of undefined
      146 |     const namespacePrefix =
      147 |       namespace && !this.schema.isNamespaceAgnostic(type) ? `${namespace}:` : '';
    > 148 |     return `${namespacePrefix}${type}:${id || uuid.v1()}`;
          |                                                    ^
      149 |   }
```
This PR refractors code according to [uuid documentation](https://github.com/uuidjs/uuid/blob/main/README.md#uuidv1options-buffer-offset). It first independently imports "v1" and calls the api as follows:  
```
import { v1 as uuidv1 } from 'uuid';
uuidv1();
```
**Jenkins test report**: https://jenkins.bfs.sichend.people.aws.dev/job/Kibana/job/bfs6.5.4_test/72/testReport/

Closes #112 