### PR TITLE
Add chromeOptions arguments in browserOptions to fix Chrome failing

### DIFF
--- a/test/functional/services/remote/leadfoot_command.js
+++ b/test/functional/services/remote/leadfoot_command.js
@@ -32,9 +32,6 @@ async function attemptToCreateCommand(log, server, driverApi) {
   log.debug('[leadfoot:command] Creating session');
 
   let browserOptions = {};
-  // if (process.env.TEST_DISABLE_GPU) {
-  //   browserOptions = { chromeOptions: { args: ['disable-gpu'] } };
-  // }
   if (process.env.TEST_BROWSER_HEADLESS) {
     browserOptions = {
       chromeOptions: {

--- a/test/functional/services/remote/leadfoot_command.js
+++ b/test/functional/services/remote/leadfoot_command.js
@@ -32,11 +32,21 @@ async function attemptToCreateCommand(log, server, driverApi) {
   log.debug('[leadfoot:command] Creating session');
 
   let browserOptions = {};
-  if (process.env.TEST_DISABLE_GPU) {
-    browserOptions = { chromeOptions: { args: ['disable-gpu'] } };
-  }
+  // if (process.env.TEST_DISABLE_GPU) {
+  //   browserOptions = { chromeOptions: { args: ['disable-gpu'] } };
+  // }
   if (process.env.TEST_BROWSER_HEADLESS) {
-    browserOptions = { chromeOptions: { args: ['headless', 'disable-gpu'] } };
+    browserOptions = {
+      chromeOptions: {
+        args: [
+          'headless',
+          'disable-gpu',
+          'no-sandbox',
+          '--enable-features=NetworkService,NetworkServiceInProcess',
+          '--disable-dev-shm-usage',
+        ]
+      }
+    };
   }
   const session = await server.createSession(browserOptions, driverApi.getRequiredCapabilities());
 


### PR DESCRIPTION
### Description : 
- Adds arguments to `chromeOptions`
- Commenting out `if (process.env.TEST_DISABLE_GPU)` conditional due to the crash continuing and `'disable-gpu'` being in the `chromeOptions`

#### Test : Jenkins Job [#54](https://jenkins.bfs.sichend.people.aws.dev/blue/organizations/jenkins/Kibana/detail/bfs6.7.2_test/54/pipeline)

#### Note : 
- The Functional Test stage has not been added so in this state will not run. Once all errors causing stage to not initiate are fixed then the stage will be added in a subsequent PR along with the fixes.

##### Reference #118 