### PR TITLE
Fix Kibana script where kibana could not be connected to

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@ node('test') {
             
             stage("Run Kibana") {
                 echo "Starting Kibana..."
-                sh "./bin/kibana --no-optimize --no-base-path 2>&1 | tee kibana.log &"
+                sh "./bin/kibana --no-base-path 2>&1 | tee kibana.log &"
             }
 
             stage('Unit Test') {


### PR DESCRIPTION
### Description : 
- Removes `--no-optomize` flag from script in `Run Kibana` stage that caused kibana to refuse connections in the Functional Test stage

#### Test : Jenkins Job [#60](https://jenkins.bfs.sichend.people.aws.dev/blue/organizations/jenkins/Kibana/detail/bfs6.7.2_test/60/pipeline)

#### Note : 
- The Functional Test stage has not been added so in this state will not run. Once all errors causing stage to not initiate are fixed then the stage will be added in a subsequent PR along with the fixes.
- Current error after this PR is detailed in issue #121 

##### Reference #120 