### PR TITLE
Update chrome & chromedriver to v79

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,6 @@ libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 lib
 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget openjdk-8-jre && \
 rm -rf /var/lib/apt/lists/*
 
-RUN curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add - && apt-get update && apt-get install -y rsync jq bsdtar --no-install-recommends && wget https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_94.0.4606.81-1_amd64.deb -O /tmp/google-chrome.deb && apt install -y /tmp/google-chrome.deb && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
 RUN apt-get update && apt-get install -y python-pip
 
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,10 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
 && unzip awscliv2.zip \
 && ./aws/install
 
+RUN aws s3 cp s3://kibana.bfs.vendor/aes/chrome/google-chrome-stable_79.0.3945.117-1_amd64.deb ./tmp/google-chrome.deb \
+&& apt install -y --allow-downgrades  /tmp/google-chrome.deb \
+&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 RUN groupadd -r kibana && useradd -r -g kibana kibana && mkdir /home/kibana && chown kibana:kibana /home/kibana
 
 USER kibana

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,9 @@ RUN curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add - 
 
 RUN apt-get update && apt-get install -y python-pip
 
-RUN pip install awscli
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+&& unzip awscliv2.zip \
+&& ./aws/install
 
 RUN groupadd -r kibana && useradd -r -g kibana kibana && mkdir /home/kibana && chown kibana:kibana /home/kibana
 

--- a/package.json
+++ b/package.json
@@ -337,7 +337,7 @@
     "chance": "1.0.10",
     "cheerio": "0.22.0",
     "chokidar": "1.6.0",
-    "chromedriver": "^74.0.0",
+    "chromedriver": "^79.0.0",
     "classnames": "2.2.5",
     "dedent": "^0.7.0",
     "delete-empty": "^2.0.0",


### PR DESCRIPTION
### Description : 

This PR contains 3 commits that together close issue #121. 

- It was decided to downgrade `chrome` to v79 and upgrade `chromedriver` to v79.  
- This version of chrome is no longer officially supported so downloading it from an s3 bucket was necessary
- The previous installation of `awscli` was incorrect and was therefore changed in the dockerfile.

#### Test : Jenkins Job [#95]( https://jenkins.bfs.sichend.people.aws.dev/blue/organizations/jenkins/Kibana/detail/bfs6.7.2_test/95/pipeline)

#### Note : 
- Functional Test stage has not been added yet and is being used for testing in jenkins (which the above test shows is running successfully). This is due to the Functional Test stage not running in parallel yet and thus taking around 2 hours. 
- The next steps will be to run the stage in parallel