### PR TITLE
Add Functional Test stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,6 +70,33 @@ node('test') {
                 junit 'target/junit/TEST-Jest Integration Tests*.xml'
             }
 
+             stage("Run Functional Test") {
+                sh "sleep 120"
+                sh "curl localhost:9200"
+                sh "curl localhost:5601"
+                echo "Start Functional Tests"
+                
+                withEnv([
+                    "TEST_BROWSER_HEADLESS=1",
+                    "CI=1",
+                    "TEST_ES_PORT=9200",
+                    "TEST_KIBANA_PORT=5601",
+                    "TEST_KIBANA_PROTOCOL=http",
+                    "TEST_ES_PROTOCOL=http",
+                    "TEST_KIBANA_HOSTNAME=localhost",
+                    "TEST_ES_HOSTNAME=localhost"
+                ]) {
+                
+                    def utResult = sh returnStatus: true, script: 'CI=1 GCS_UPLOAD_PREFIX=fake node scripts/functional_test_runner'
+    
+                    if (utResult != 0) {
+                        currentBuild.result = 'FAILURE'
+                    }
+
+                    junit 'target/junit/ci*/**.xml'
+                }
+            }
+
         }     
     } catch (e) {
         echo 'This will run only if failed'


### PR DESCRIPTION
### Description : 
Adds the `Functional Test` stage to jenkinsfile

#### Note : 
- This will not run in parallel in its current state. Currently takes close to 4hrs to complete.
- Junit reporting file path is incorrect resulting in a failure for the stage even after it has fully completed and the results can be seen in the log.
- Will be updated to parallel & Junit path resolved in a subsequent PR.

#### Test : Jenkins Job [#120](https://jenkins.bfs.sichend.people.aws.dev/blue/organizations/jenkins/Kibana/detail/bfs6.7.2_test/120/pipeline)

#### Reference : Issue #125 