### PR TITLE
Fix junit reporting file script

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,13 +93,14 @@ node('test') {
                         currentBuild.result = 'FAILURE'
                     }
 
-                    junit 'target/junit/ci*/**.xml'
+                    junit 'target/junit/TEST-UI Functional Tests.xml'
                 }
             }
 
         }     
     } catch (e) {
         echo 'This will run only if failed'
+        junit 'target/junit/TEST-UI Functional Tests.xml'
         currentBuild.result = 'FAILURE'
         throw e
     }


### PR DESCRIPTION
### Description : 
Changes the junit reporting script directory to fix junit report not showing in blue ocean. 

#### Test : [Job #144](https://jenkins.bfs.sichend.people.aws.dev/blue/organizations/jenkins/Kibana/detail/bfs6.7.2_test/144/tests)

#### Note : 
This test job has all but one of the functional tests suites removed for testing the script efficiently. This PR does not have those changes and therefore will show a report for all functional tests.

#### Closes : Issue #128 