### PR TITLE
Make Functional Test stage run in parallel

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,39 +97,53 @@ node('test') {
                 
                 }
             }
+        }  
+        stage('Functional Test') {
+            functionalDynamicParallelSteps(testImage);
 
-             stage("Run Functional Test") {
-                sh "sleep 120"
-                sh "curl localhost:9200"
-                sh "curl localhost:5601"
-                echo "Start Functional Tests"
-                
-                withEnv([
-                    "TEST_BROWSER_HEADLESS=1",
-                    "CI=1",
-                    "TEST_ES_PORT=9200",
-                    "TEST_KIBANA_PORT=5601",
-                    "TEST_KIBANA_PROTOCOL=http",
-                    "TEST_ES_PROTOCOL=http",
-                    "TEST_KIBANA_HOSTNAME=localhost",
-                    "TEST_ES_HOSTNAME=localhost"
-                ]) {
-                
-                    def utResult = sh returnStatus: true, script: 'CI=1 GCS_UPLOAD_PREFIX=fake node scripts/functional_test_runner'
-    
-                    if (utResult != 0) {
-                        currentBuild.result = 'FAILURE'
-                    }
-
-                    junit 'target/junit/TEST-UI Functional Tests.xml'
-                }
-            }
-
-        }     
+            junit 'target/junit/ci*/*.xml'
+        } 
     } catch (e) {
         echo 'This will run only if failed'
-        junit 'target/junit/TEST-UI Functional Tests.xml'
         currentBuild.result = 'FAILURE'
         throw e
     }
+}
+
+def functionalDynamicParallelSteps(image){
+    ciGroupsMap = [:]
+    for (int i = 1; i <= 12; i++) {
+        def currentCiGroup = "ciGroup${i}";
+        def currentStep = i;
+        ciGroupsMap["${currentCiGroup}"] = {
+            sh "rm -rf ${env.WORKSPACE}/data/${currentCiGroup}"
+            sh "mkdir -p ${env.WORKSPACE}/data/${currentCiGroup}"
+            stage("${currentCiGroup}") {
+                withEnv([
+                    "TEST_BROWSER_HEADLESS=1",
+                    "CI=1",
+                    "GCS_UPLOAD_PREFIX=fake",
+                    "TEST_ES_PORT=9200",
+                    "TEST_KIBANA_PORT=5601",
+                    "TEST_KIBANA_PROTOCOL=http",
+                    "TEST_ES_HOSTNAME=localhost",
+                    "CACHE_DIR=${currentCiGroup}"
+                ]) {
+                    image.inside("-v \'${env.WORKSPACE}/data/${currentCiGroup}:${env.WORKSPACE}/elasticsearch-6.7.2/data\'"){
+                       sh './elasticsearch-6.7.2/bin/elasticsearch & '
+                       
+                       echo "Starting Kibana..."
+                       sh "./bin/kibana --no-base-path &"
+                       
+                       sh "sleep 180"
+                       sh "curl localhost:9200"
+                       sh "curl localhost:5601"
+                       echo "Start Functional Tests"
+                       sh "node scripts/functional_test_runner --config test/functional/config.js --include-tag ${currentCiGroup}"
+                    }
+                }
+            }
+        }
+    }
+    parallel ciGroupsMap
 }


### PR DESCRIPTION
### Description : 
Updates the jenkinsfile to run the Functional Test stage in parallel which saves close to 4 hours per job. 

#### Test : [Job #159](https://jenkins.bfs.sichend.people.aws.dev/job/Kibana/job/bfs6.7.2_test/159/)

#### Closes : Issue #124 